### PR TITLE
Make hotfix workflow reusable across dashboard repos

### DIFF
--- a/.github/actions/prepare-hotfix/action.yaml
+++ b/.github/actions/prepare-hotfix/action.yaml
@@ -1,0 +1,18 @@
+name: Prepare Hotfix
+
+runs:
+  using: composite
+  steps:
+    - name: Add hotfix branch to .yarnrc.yml
+      shell: bash
+      run: |
+        cat <<EOT >> .yarnrc.yml
+
+changesetBaseRefs:
+  - "master"
+  - "origin/master"
+  - "$HOTFIX_BRANCH"
+  - "origin/$HOTFIX_BRANCH"
+EOT
+        git add .yarnrc.yml
+        git commit -m "Add hotfix branch to changesetBaseRefs in .yarnrc.yml"

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -7,6 +7,22 @@ on:
         description: 'The tag for which the hotfix should be created'
         required: true
         type: string
+      callback_action_path:
+        description: 'Optional path to a callback action executed after bumping the version'
+        required: false
+        type: string
+        default: '.github/actions/prepare-hotfix'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'The tag for which the hotfix should be created'
+        required: true
+        type: string
+      callback_action_path:
+        description: 'Optional path to a callback action executed after bumping the version'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: none  # we rely on the GitHub App token instead
@@ -73,18 +89,16 @@ jobs:
           repository-operation: commit-to-head
           commit-message: Bump patch version to ${version} for hotfix
 
-      - name: Update and commit .yarnrc.yml
+      - name: Prepare callback action
+        if: inputs.callback_action_path != ''
+        shell: bash
         run: |
-          cat <<EOF >> .yarnrc.yml
+          set -eu
+          cp -r "${{ inputs.callback_action_path }}" ../hotfix-callback-action
 
-          changesetBaseRefs:
-            - "master"
-            - "origin/master"
-            - "$HOTFIX_BRANCH"
-            - "origin/$HOTFIX_BRANCH"
-          EOF
-          git add .yarnrc.yml
-          git commit -m "Add hotfix branch to changesetBaseRefs in .yarnrc.yml"
+      - name: Repository specific preparation
+        if: inputs.callback_action_path != ''
+        uses: ./../hotfix-callback-action
 
       - name: Push prepare branch and create Pull Request
         env:
@@ -95,4 +109,4 @@ jobs:
             --base "$HOTFIX_BRANCH" \
             --head "$PREPARE_BRANCH" \
             --title "[$HOTFIX_BRANCH] Prepare hotfix branch" \
-            --body "Bumps the patch version and adds the hotfix branch references to .yarnrc.yml for release preparation."
+            --body "Bumps the patch version for release preparation."


### PR DESCRIPTION
## Summary
- make `prepare-hotfix-branch` workflow reusable via `workflow_call`
- add optional callback action and new `prepare-hotfix` action for yarnrc updates
- copy callback action to a static path before executing it

## Testing
- `yarn install --immutable` *(fails: unrs-resolver couldn't be built)*
- `make test` *(fails: workspace backend/charts/frontend/polling-watcher/request exited with errors)*
- `pre-commit run --files .github/workflows/prepare-hotfix-branch.yaml .github/actions/prepare-hotfix/action.yaml` *(fails: could not fetch detect-secrets repo over SSH)*

------
https://chatgpt.com/codex/tasks/task_e_689c536ce5ac8320a1b90f75e10fba48